### PR TITLE
fix: fall back to Situation id if Period or RoadAuthority misses an id

### DIFF
--- a/src/Parsers/PeriodParser.php
+++ b/src/Parsers/PeriodParser.php
@@ -10,7 +10,7 @@ use Swis\Melvin\Models\Week;
 
 class PeriodParser
 {
-    public function parse(\stdClass $object, int $index): Period
+    public function parse(\stdClass $object, int $index, int $situationId): Period
     {
         if ($repeatingAt = $object->repeatingAt ?? null) {
             $repeatingAt = new Week(
@@ -23,9 +23,8 @@ class PeriodParser
                 $repeatingAt[6]
             );
         }
-
         return new Period(
-            $object->id,
+            $object->id ?? $situationId,
             ($object->name ?? '') ?: sprintf('Uitvoerperiode %d', $index + 1),
             new \DateTime($object->startDateActual ?? $object->startDate, new \DateTimeZone('UTC')),
             ($endDate = $object->endDateActual ?? $object->endDate ?? null) ? new \DateTime($endDate, new \DateTimeZone('UTC')) : null,

--- a/src/Parsers/SituationParser.php
+++ b/src/Parsers/SituationParser.php
@@ -48,9 +48,11 @@ class SituationParser
 
     public function parse(\stdClass $object, array $restrictions, array $detours = []): Situation
     {
+        $situationId = (int)$object->id;
+
         if ($roadAuthority = $object->properties->roadAuthority ?? null) {
             $roadAuthority = new RoadAuthority(
-                $roadAuthority->id,
+                $roadAuthority->id ?? $situationId,
                 $roadAuthority->type !== 'EMPTY' ? RoadAuthorityType::from($roadAuthority->type) : null,
                 $roadAuthority->name
             );
@@ -113,7 +115,7 @@ class SituationParser
             SituationStatus::from($object->properties->status),
             $roadAuthority,
             $location,
-            array_map([$this->periodParser, 'parse'], $object->properties->periods, array_keys($object->properties->periods)),
+            array_map([$this->periodParser, 'parse'], $object->properties->periods, array_keys($object->properties->periods), array_fill(0, count($object->properties->periods), $situationId)),
             $createdAt,
             $createdBy,
             $lastChangedAt,


### PR DESCRIPTION
## Description

in some cases Periods and RoadAuthorities no longer have an id, when this occurs the Feature id is set.

## Motivation and context

In Mappi, an Integer is expected for the Id's of these objects. If this is a Null the code crashes. Therefore if the objects dont have an id, the id of the parent is used.

## How has this been tested?

By importing from the source in Mappi

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
