### PR TITLE
fix: city of a location can be null

### DIFF
--- a/src/Models/Location.php
+++ b/src/Models/Location.php
@@ -7,7 +7,7 @@ namespace Swis\Melvin\Models;
 class Location
 {
     public function __construct(
-        public string $city,
+        public ?string $city,
         public string $road,
         public ?string $district,
         public string $comment,

--- a/tests/_files/situations-schema.json
+++ b/tests/_files/situations-schema.json
@@ -578,7 +578,14 @@
             "additionalProperties": false,
             "properties": {
                 "city": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "road": {
                     "type": "string"
@@ -605,7 +612,6 @@
                 }
             },
             "required": [
-                "city",
                 "road"
             ],
             "title": "Location"


### PR DESCRIPTION
## Description

Some locations will return an empty string for the city name. This results in the package to throw an error due to a non-nullable city property on Location. 

## Motivation and context

The package throws errors when the city property is empty. This PR resolves it.

## How has this been tested?

I have ran a test importing the data. Some of the situations had an empty string. One of these is https://melvin.ndw.nu/melvinservice/rest/public/situation/385390

Running the integration tests will show that it now works again

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
