### PR TITLE
fix: ternary check for vehicleTypes and boatTypes

### DIFF
--- a/src/Parsers/DetourParser.php
+++ b/src/Parsers/DetourParser.php
@@ -25,8 +25,8 @@ class DetourParser
             ($object->properties->name ?? '') ?: sprintf('Omleiding %d', $index + 1),
             Direction::from($object->properties->direction),
             !empty($object->properties->transportMode) ? TransportMode::from($object->properties->transportMode) : null,
-            array_map([VehicleType::class, 'from'], $object->properties->vehicleTypes),
-            array_map([BoatType::class, 'from'], $object->properties->boatTypes)
+            array_map([VehicleType::class, 'from'], $object->properties->vehicleTypes ?? []),
+            array_map([BoatType::class, 'from'], $object->properties->boatTypes ?? [])
         );
     }
 }


### PR DESCRIPTION
## Description

Some detours can have no `vehicleTypes` or `boatTypes`, they are not an empty array but `null`.

## Motivation and context

The package throws errors when the vehicleTypes or boatTypes is null. This PR resolves it.

## How has this been tested?

I have ran a test importing the data. Some of the situation had no vehicleTypes or boatTypes.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.
