### PR TITLE
fix: Roads of a location can be null

### DIFF
--- a/src/Models/Location.php
+++ b/src/Models/Location.php
@@ -8,7 +8,7 @@ class Location
 {
     public function __construct(
         public ?string $city,
-        public string $road,
+        public ?string $road,
         public ?string $district,
         public string $comment,
     ) {

--- a/src/Parsers/SituationParser.php
+++ b/src/Parsers/SituationParser.php
@@ -147,9 +147,9 @@ class SituationParser
                 ' ',
                 sprintf(
                     '%s %s %s %s %s',
-                    $object->properties->location->road,
-                    $object->properties->location->district,
-                    $object->properties->location->city,
+                    $object->properties->location->road ?? '',
+                    $object->properties->location->district ?? '',
+                    $object->properties->location->city ?? '',
                     $description,
                     $object->properties->addition ?? ''
                 )

--- a/tests/_files/situations-schema.json
+++ b/tests/_files/situations-schema.json
@@ -612,7 +612,14 @@
                     ]
                 },
                 "road": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "district": {
                     "anyOf": [
@@ -635,9 +642,6 @@
                     ]
                 }
             },
-            "required": [
-                "road"
-            ],
             "title": "Location"
         },
         "Period": {


### PR DESCRIPTION
## Description

Some locations will return an empty string for the road name. This results in the package to throw an error due to a non-nullable road on Location.

## Motivation and context

The package throws errors when the road property is empty. This PR resolves it.

## How has this been tested?

Running the integration tests will show that it now works again

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the [schema](tests/_files/situations-schema.json), I have updated it accordingly.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
