### PR TITLE
Hotfix/contact and person attributes can be null

### DIFF
--- a/src/Models/Contact.php
+++ b/src/Models/Contact.php
@@ -7,19 +7,19 @@ namespace Swis\Melvin\Models;
 class Contact
 {
     public function __construct(
-        public int $contactId,
-        public string $firstName,
-        public string $prefix,
-        public string $lastName,
+        public ?int $contactId,
+        public ?string $firstName,
+        public ?string $prefix,
+        public ?string $lastName,
         public string $email,
-        public string $phone,
+        public ?string $phone,
         public ?string $organisation,
-        public int $parentSituationId,
+        public ?int $parentSituationId,
         public string $function,
-        public string $publicPhone,
-        public bool $active,
-        public int $createdById,
-        public int $changedById,
+        public ?string $publicPhone,
+        public ?bool $active,
+        public ?int $createdById,
+        public ?int $changedById,
     ) {
     }
 }

--- a/src/Models/Person.php
+++ b/src/Models/Person.php
@@ -10,7 +10,7 @@ class Person
 {
     public function __construct(
         public string $firstName,
-        public string $prefix,
+        public ?string $prefix,
         public string $lastName,
         public PersonType $type,
     ) {

--- a/src/Models/Situation.php
+++ b/src/Models/Situation.php
@@ -63,7 +63,7 @@ class Situation
         /**
          * @var string[]
          */
-        public array $remarks,
+        public ?array $remarks,
         /**
          * @var \Swis\Melvin\Models\Contact[]
          */

--- a/src/Parsers/ContactParser.php
+++ b/src/Parsers/ContactParser.php
@@ -11,19 +11,19 @@ class ContactParser
     public function parse(\stdClass $object): Contact
     {
         return new Contact(
-            $object->contactId,
-            $object->firstName,
-            $object->prefix,
-            $object->lastName,
+            $object->contactId ?? null,
+            $object->firstName ?? null,
+            $object->prefix ?? null,
+            $object->lastName ?? null,
             $object->email,
             $object->phone,
             $object->organisation ?? $object->organization,
-            $object->parentSituationId,
+            $object->parentSituationId ?? null,
             $object->function,
-            $object->publicPhone,
-            $object->active,
-            $object->createdById,
-            $object->changedById
+            $object->publicPhone ?? null,
+            $object->active ?? null,
+            $object->createdById ?? null,
+            $object->changedById ?? null
         );
     }
 }

--- a/src/Parsers/SituationParser.php
+++ b/src/Parsers/SituationParser.php
@@ -112,7 +112,7 @@ class SituationParser
             array_map([$this->detourParser, 'parse'], $detours, array_keys($detours)),
             ($object->properties->permitId ?? '') ?: null,
             ($object->properties->referenceId ?? '') ?: null,
-            $object->properties->remarks,
+            ($object->properties->remarks ?? '') ?: null,
             array_map([$this->contactParser, 'parse'], $object->properties->contacts ?? []),
         );
     }

--- a/tests/_files/situations-schema.json
+++ b/tests/_files/situations-schema.json
@@ -378,10 +378,17 @@
                     ]
                 },
                 "remarks": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "contacts": {
                     "type": "array",
@@ -421,19 +428,47 @@
             "additionalProperties": false,
             "properties": {
                 "firstName": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "prefix": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "lastName": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "email": {
                     "type": "string"
                 },
                 "phone": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "organisation": {
                     "anyOf": [
@@ -446,10 +481,24 @@
                     ]
                 },
                 "parentSituationId": {
-                    "type": "integer"
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "contactId": {
-                    "type": "integer"
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "organization": {
                     "anyOf": [
@@ -465,16 +514,44 @@
                     "type": "string"
                 },
                 "publicPhone": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "active": {
-                    "type": "boolean"
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "createdById": {
-                    "type": "integer"
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "changedById": {
-                    "type": "integer"
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [
@@ -502,7 +579,14 @@
                     "type": "string"
                 },
                 "prefix": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "lastName": {
                     "type": "string"

--- a/tests/_fixtures/melvin.ndw.nu/melvinservice/rest/area/all.get.mock
+++ b/tests/_fixtures/melvin.ndw.nu/melvinservice/rest/area/all.get.mock
@@ -1,7 +1,7 @@
 [
   {
-    "name": "Het Hogeland",
-    "id": 479,
+    "name": "Bunnik",
+    "id": 321,
     "type": "MUNICIPALITY"
   },
   {
@@ -10,8 +10,8 @@
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Westerkwartier",
-    "id": 480,
+    "name": "Veenendaal",
+    "id": 339,
     "type": "MUNICIPALITY"
   },
   {
@@ -65,11 +65,6 @@
     "type": "TUNNEL_AUTHORITY"
   },
   {
-    "name": "PWN",
-    "id": 507,
-    "type": "UNKNOWN"
-  },
-  {
     "name": "Rotterdam (Prins Alexander)",
     "id": 450,
     "type": "SUBMUNICIPALITY"
@@ -95,16 +90,6 @@
     "type": "PROVINCE"
   },
   {
-    "name": "Vught",
-    "id": 216,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Eemsdelta",
-    "id": 506,
-    "type": "MUNICIPALITY"
-  },
-  {
     "name": "'s-Gravenhage (Segbroek)",
     "id": 460,
     "type": "SUBMUNICIPALITY"
@@ -115,44 +100,24 @@
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Land van Cuijk",
-    "id": 579,
-    "type": "MUNICIPALITY"
-  },
-  {
     "name": "Zuid-Nederland District West",
     "id": 316,
     "type": "ROAD_AUTHORITY"
   },
   {
-    "name": "Purmerend",
-    "id": 259,
+    "name": "IJsselstein",
+    "id": 327,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Maashorst",
-    "id": 578,
-    "type": "MUNICIPALITY"
+    "name": "Amsterdam Weesp",
+    "id": 1142,
+    "type": "SUBMUNICIPALITY"
   },
   {
-    "name": "Zandvoort",
-    "id": 271,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Almelo",
-    "id": 276,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Voorne aan Zee",
-    "id": 904,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Haarlemmermeer",
-    "id": 242,
-    "type": "MUNICIPALITY"
+    "name": "Amsterdam Zuidoost",
+    "id": 1134,
+    "type": "SUBMUNICIPALITY"
   },
   {
     "name": "Westerscheldetunnel NV",
@@ -165,23 +130,8 @@
     "type": "SUBMUNICIPALITY"
   },
   {
-    "name": "Eindhoven",
-    "id": 178,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Loon op Zand",
-    "id": 194,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Zevenaar",
-    "id": 98,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Nieuwegein",
-    "id": 331,
+    "name": "Kapelle",
+    "id": 371,
     "type": "MUNICIPALITY"
   },
   {
@@ -190,18 +140,8 @@
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Breda",
-    "id": 171,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Weesp",
-    "id": 267,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Rozendaal",
-    "id": 88,
+    "name": "Helmond",
+    "id": 189,
     "type": "MUNICIPALITY"
   },
   {
@@ -210,39 +150,9 @@
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Leusden",
-    "id": 328,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Helmond",
-    "id": 189,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Zee en Delta District Noord",
-    "id": 313,
-    "type": "ROAD_AUTHORITY"
-  },
-  {
     "name": "Noord-Nederland District Oost",
     "id": 304,
     "type": "ROAD_AUTHORITY"
-  },
-  {
-    "name": "Zuid-Nederland District Zuid-Oost",
-    "id": 317,
-    "type": "ROAD_AUTHORITY"
-  },
-  {
-    "name": "Oost-Nederland District Oost",
-    "id": 307,
-    "type": "ROAD_AUTHORITY"
-  },
-  {
-    "name": "North Sea Port",
-    "id": 876,
-    "type": "MISCELLANEOUS"
   },
   {
     "name": "Schiermonnikoog",
@@ -250,153 +160,43 @@
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Simpelveld",
-    "id": 149,
+    "name": "Amsterdam Zuid",
+    "id": 1140,
+    "type": "SUBMUNICIPALITY"
+  },
+  {
+    "name": "Amsterdam Noord",
+    "id": 1136,
+    "type": "SUBMUNICIPALITY"
+  },
+  {
+    "name": "Amsterdam Westpoort",
+    "id": 1137,
+    "type": "SUBMUNICIPALITY"
+  },
+  {
+    "name": "Amsterdam Nieuw-West",
+    "id": 1139,
+    "type": "SUBMUNICIPALITY"
+  },
+  {
+    "name": "Katwijk",
+    "id": 402,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Utrecht",
-    "id": 337,
+    "name": "Kerkrade",
+    "id": 135,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Amersfoort",
-    "id": 318,
-    "type": "MUNICIPALITY"
+    "name": "Amsterdam Oost",
+    "id": 1141,
+    "type": "SUBMUNICIPALITY"
   },
   {
-    "name": "Amsterdam",
-    "id": 227,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Deurne",
-    "id": 174,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Baarn",
-    "id": 319,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Utrechtse Heuvelrug",
-    "id": 338,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Bunschoten",
-    "id": 322,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Renswoude",
-    "id": 333,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Wijk bij Duurstede",
-    "id": 341,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Woudenberg",
-    "id": 343,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Rhenen",
-    "id": 334,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Gemert-Bakel",
-    "id": 182,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Terschelling",
-    "id": 41,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "De Bilt",
-    "id": 323,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Lopik",
-    "id": 329,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "IJsselstein",
-    "id": 327,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Waalwijk",
-    "id": 218,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Soest",
-    "id": 335,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Houten",
-    "id": 326,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "'s-Hertogenbosch",
-    "id": 206,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Veenendaal",
-    "id": 339,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Baarle-Nassau",
-    "id": 162,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Zeist",
-    "id": 344,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Vlieland",
-    "id": 43,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Bunnik",
-    "id": 321,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Tilburg",
-    "id": 212,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Leeuwarden",
-    "id": 32,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Zee en Delta District Zuid",
-    "id": 314,
-    "type": "ROAD_AUTHORITY"
-  },
-  {
-    "name": "West-Nederland Noord District Noord",
-    "id": 309,
+    "name": "Midden-Nederland District Noord",
+    "id": 302,
     "type": "ROAD_AUTHORITY"
   },
   {
@@ -405,8 +205,18 @@
     "type": "ROAD_AUTHORITY"
   },
   {
-    "name": "Midden-Nederland District Noord",
-    "id": 302,
+    "name": "Oost-Nederland District Zuid",
+    "id": 308,
+    "type": "ROAD_AUTHORITY"
+  },
+  {
+    "name": "West-Nederland Noord District Noord",
+    "id": 309,
+    "type": "ROAD_AUTHORITY"
+  },
+  {
+    "name": "Zee en Delta District Zuid",
+    "id": 314,
     "type": "ROAD_AUTHORITY"
   },
   {
@@ -415,33 +225,8 @@
     "type": "ROAD_AUTHORITY"
   },
   {
-    "name": "Oost-Nederland District Zuid",
-    "id": 308,
-    "type": "ROAD_AUTHORITY"
-  },
-  {
-    "name": "Midden-Nederland District Zuid",
-    "id": 303,
-    "type": "ROAD_AUTHORITY"
-  },
-  {
-    "name": "Capelle aan den IJssel",
-    "id": 389,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "De Fryske Marren",
-    "id": 24,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Veldhoven",
-    "id": 215,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Westland",
-    "id": 436,
+    "name": "Geertruidenberg",
+    "id": 180,
     "type": "MUNICIPALITY"
   },
   {
@@ -460,413 +245,8 @@
     "type": "ROAD_AUTHORITY"
   },
   {
-    "name": "De Ronde Venen",
-    "id": 324,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Krimpenerwaard",
-    "id": 406,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Teylingen",
-    "id": 431,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Gouda",
-    "id": 396,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Bodegraven-Reeuwijk",
-    "id": 387,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Midden-Delfland",
-    "id": 414,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Delft",
-    "id": 391,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Midden-Groningen",
-    "id": 446,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Wassenaar",
-    "id": 435,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Krimpen aan den IJssel",
-    "id": 405,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Gorinchem",
-    "id": 395,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Nissewaard",
-    "id": 417,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Zoeterwoude",
-    "id": 440,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Lansingerland",
-    "id": 407,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Katwijk",
-    "id": 402,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "'s-Gravenhage",
-    "id": 428,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Westerwolde",
-    "id": 445,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Hardinxveld-Giessendam",
-    "id": 397,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Waddinxveen",
-    "id": 434,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Zoetermeer",
-    "id": 439,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Waadhoeke",
-    "id": 444,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Lisse",
-    "id": 412,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Barendrecht",
-    "id": 385,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Alphen aan den Rijn",
-    "id": 384,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Alblasserdam",
-    "id": 382,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Leiderdorp",
-    "id": 410,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Leiden",
-    "id": 409,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Nieuwkoop",
-    "id": 416,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Deventer",
-    "id": 279,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Schagen",
-    "id": 260,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Venlo",
-    "id": 154,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Stein",
-    "id": 151,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Valkenswaard",
-    "id": 214,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Sint-Michielsgestel",
-    "id": 208,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Tynaarlo",
-    "id": 11,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Heerlen",
-    "id": 133,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Oude IJsselstreek",
-    "id": 82,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Smallingerland",
-    "id": 39,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Bronckhorst",
-    "id": 53,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Zwartewaterland",
-    "id": 299,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Staphorst",
-    "id": 294,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Montfoort",
-    "id": 330,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Hellendoorn",
-    "id": 284,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Mook en Middelaar",
-    "id": 141,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Beek",
-    "id": 125,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Aalsmeer",
-    "id": 224,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Meerssen",
-    "id": 140,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Zundert",
-    "id": 222,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Hengelo",
-    "id": 285,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Renkum",
-    "id": 85,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Bernheze",
-    "id": 165,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Achtkarspelen",
-    "id": 21,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Heerde",
-    "id": 68,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Zutphen",
-    "id": 99,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Harderwijk",
-    "id": 66,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Leudal",
-    "id": 137,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Haarlem",
-    "id": 240,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Laren",
-    "id": 254,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Putten",
-    "id": 84,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Texel",
-    "id": 262,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Castricum",
-    "id": 233,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Woerden",
-    "id": 342,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Wierden",
-    "id": 298,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Gooise Meren",
-    "id": 239,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Drimmelen",
-    "id": 176,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Gulpen-Wittem",
-    "id": 132,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Hardenberg",
-    "id": 283,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Twenterand",
-    "id": 297,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Bergen (NH.)",
-    "id": 229,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Losser",
-    "id": 288,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Heusden",
-    "id": 190,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Waalre",
-    "id": 217,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Alkmaar",
-    "id": 225,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Nederweert",
-    "id": 142,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Oostzaan",
-    "id": 256,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Moerdijk",
-    "id": 197,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Landsmeer",
-    "id": 252,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Ooststellingwerf",
-    "id": 36,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Súdwest-Fryslân",
-    "id": 40,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Brunssum",
-    "id": 128,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Kaag en Braassem",
-    "id": 401,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Oss",
-    "id": 202,
+    "name": "Geldrop-Mierlo",
+    "id": 181,
     "type": "MUNICIPALITY"
   },
   {
@@ -875,418 +255,28 @@
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Rheden",
-    "id": 86,
+    "name": "Gorinchem",
+    "id": 395,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Drechterland",
-    "id": 236,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Amstelveen",
-    "id": 226,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Medemblik",
-    "id": 255,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Wijchen",
-    "id": 95,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Wijdemeren",
-    "id": 268,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Nuenen, Gerwen en Nederwetten",
-    "id": 198,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Haaksbergen",
-    "id": 282,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Rucphen",
-    "id": 205,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Rijssen-Holten",
-    "id": 293,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Meierijstad",
-    "id": 195,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Oldebroek",
-    "id": 80,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Heemstede",
-    "id": 244,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Geertruidenberg",
-    "id": 180,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Horst aan de Maas",
-    "id": 134,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Wormerland",
-    "id": 269,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Ouder-Amstel",
-    "id": 258,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Westervoort",
-    "id": 94,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Overbetuwe",
-    "id": 83,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Dantumadiel",
-    "id": 23,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Peel en Maas",
-    "id": 145,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Ommen",
-    "id": 291,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Aalten",
-    "id": 46,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Noordenveld",
-    "id": 10,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Cranendonck",
-    "id": 172,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Bergen (L.)",
-    "id": 127,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Doesburg",
-    "id": 57,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Assen",
-    "id": 2,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Eersel",
-    "id": 177,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Oisterwijk",
-    "id": 200,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Epe",
-    "id": 63,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Heerenveen",
-    "id": 29,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Groningen",
-    "id": 107,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Sittard-Geleen",
-    "id": 150,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Venray",
-    "id": 155,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Someren",
-    "id": 209,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Echt-Susteren",
-    "id": 129,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "De Wolden",
-    "id": 5,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Westerveld",
-    "id": 12,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Hattem",
-    "id": 67,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Borger-Odoorn",
-    "id": 3,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Druten",
-    "id": 59,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Doetinchem",
-    "id": 58,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Hoogeveen",
-    "id": 7,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Berkelland",
-    "id": 51,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Heumen",
-    "id": 69,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Arnhem",
-    "id": 48,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Maasdriel",
-    "id": 73,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Wageningen",
-    "id": 92,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Nijmegen",
-    "id": 78,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Nunspeet",
-    "id": 79,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Best",
-    "id": 166,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Scherpenzeel",
-    "id": 89,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Veere",
-    "id": 379,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Vlissingen",
-    "id": 380,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Rotterdam",
-    "id": 426,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Goes",
-    "id": 369,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Kapelle",
-    "id": 371,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Middelburg",
-    "id": 372,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Noord-Beveland",
-    "id": 373,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Voorschoten",
-    "id": 433,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Vlaardingen",
-    "id": 432,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Schiedam",
-    "id": 427,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Reimerswaal",
-    "id": 374,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Rijswijk",
-    "id": 425,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Tholen",
-    "id": 378,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Hulst",
-    "id": 370,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Enschede",
-    "id": 281,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Midden-Drenthe",
-    "id": 9,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Heiloo",
-    "id": 246,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Pijnacker-Nootdorp",
-    "id": 423,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Ridderkerk",
-    "id": 424,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Terneuzen",
-    "id": 377,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Sluis",
-    "id": 376,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Sliedrecht",
-    "id": 429,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Boekel",
-    "id": 168,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Winterswijk",
-    "id": 96,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Coevorden",
-    "id": 4,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Nijkerk",
-    "id": 77,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Hillegom",
-    "id": 400,
-    "type": "MUNICIPALITY"
+    "name": "PWN",
+    "id": 507,
+    "type": "UNKNOWN"
   },
   {
-    "name": "Dongen",
-    "id": 175,
+    "name": "Krimpen aan den IJssel",
+    "id": 405,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Diemen",
-    "id": 235,
+    "name": "Aalsmeer",
+    "id": 224,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Oldenzaal",
-    "id": 289,
+    "name": "Drimmelen",
+    "id": 176,
     "type": "MUNICIPALITY"
   },
   {
@@ -1295,13 +285,73 @@
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Borsele",
-    "id": 368,
+    "name": "Achtkarspelen",
+    "id": 21,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Hollands Kroon",
-    "id": 248,
+    "name": "Alblasserdam",
+    "id": 382,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Beek",
+    "id": 125,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Hendrik-Ido-Ambacht",
+    "id": 399,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Albrandswaard",
+    "id": 383,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Laren",
+    "id": 254,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Berkelland",
+    "id": 51,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Alkmaar",
+    "id": 225,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Almelo",
+    "id": 276,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Bernheze",
+    "id": 165,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Best",
+    "id": 166,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Bloemendaal",
+    "id": 232,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Borne",
+    "id": 277,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Aalten",
+    "id": 46,
     "type": "MUNICIPALITY"
   },
   {
@@ -1310,8 +360,18 @@
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Zwijndrecht",
-    "id": 442,
+    "name": "Oldenzaal",
+    "id": 289,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Borsele",
+    "id": 368,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Gilze en Rijen",
+    "id": 183,
     "type": "MUNICIPALITY"
   },
   {
@@ -1320,208 +380,53 @@
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Valkenburg aan de Geul",
-    "id": 153,
+    "name": "Boxtel",
+    "id": 170,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Zeewolde",
-    "id": 19,
+    "name": "Gooise Meren",
+    "id": 239,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Apeldoorn",
-    "id": 47,
+    "name": "Gouda",
+    "id": 396,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Eemnes",
-    "id": 325,
+    "name": "Alphen aan den Rijn",
+    "id": 384,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Kerkrade",
-    "id": 135,
+    "name": "Voerendaal",
+    "id": 156,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Voorst",
-    "id": 91,
+    "name": "Alphen-Chaam",
+    "id": 160,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Geldrop-Mierlo",
-    "id": 181,
+    "name": "Hardinxveld-Giessendam",
+    "id": 397,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Veendam",
-    "id": 120,
+    "name": "Amstelveen",
+    "id": 226,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Noordwijk",
-    "id": 418,
+    "name": "Bunschoten",
+    "id": 322,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Beuningen",
-    "id": 52,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Woensdrecht",
-    "id": 220,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Lochem",
-    "id": 72,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Asten",
-    "id": 161,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Ede",
-    "id": 61,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Meppel",
-    "id": 8,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Hoorn",
-    "id": 249,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Stede Broec",
-    "id": 261,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Noardeast-Fryslân",
-    "id": 467,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Steenwijkerland",
-    "id": 295,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Dinkelland",
-    "id": 280,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Bergen op Zoom",
-    "id": 164,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Altena",
-    "id": 462,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Beekdaelen",
-    "id": 461,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "West Betuwe",
-    "id": 463,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "West-Nederland Noord District Zuid",
-    "id": 310,
-    "type": "ROAD_AUTHORITY"
-  },
-  {
-    "name": "Vijfheerenlanden",
-    "id": 464,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Zuid-Holland",
-    "id": 443,
-    "type": "PROVINCE"
-  },
-  {
-    "name": "Urk",
-    "id": 18,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Gennep",
-    "id": 131,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Kampen",
-    "id": 287,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Maastricht",
-    "id": 139,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Heemskerk",
-    "id": 243,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Oirschot",
-    "id": 199,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Noordoostpolder",
-    "id": 17,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Emmen",
-    "id": 6,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Elburg",
-    "id": 62,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Etten-Leur",
-    "id": 179,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Neder-Betuwe",
-    "id": 75,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Buren",
-    "id": 55,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Velsen",
-    "id": 265,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Oosterhout",
-    "id": 201,
+    "name": "Castricum",
+    "id": 233,
     "type": "MUNICIPALITY"
   },
   {
@@ -1530,93 +435,58 @@
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Boxtel",
-    "id": 170,
+    "name": "Hengelo",
+    "id": 285,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Hoeksche Waard",
-    "id": 466,
+    "name": "Amsterdam",
+    "id": 227,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Tytsjerksteradiel",
-    "id": 42,
+    "name": "Zuid-Holland",
+    "id": 443,
+    "type": "PROVINCE"
+  },
+  {
+    "name": "Hoorn",
+    "id": 249,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Tubbergen",
-    "id": 296,
+    "name": "Elburg",
+    "id": 62,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Montferland",
-    "id": 74,
+    "name": "Cranendonck",
+    "id": 172,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Uithoorn",
-    "id": 264,
+    "name": "Huizen",
+    "id": 250,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Bergeijk",
-    "id": 163,
+    "name": "Apeldoorn",
+    "id": 47,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Brummen",
-    "id": 54,
+    "name": "Arnhem",
+    "id": 48,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Ermelo",
-    "id": 64,
+    "name": "Assen",
+    "id": 2,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Bladel",
-    "id": 167,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "West Maas en Waal",
-    "id": 93,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Oost Gelre",
-    "id": 81,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Barneveld",
-    "id": 49,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Roermond",
-    "id": 147,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Raalte",
-    "id": 292,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Hilvarenbeek",
-    "id": 191,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Eijsden-Margraten",
-    "id": 130,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Laarbeek",
-    "id": 192,
+    "name": "Asten",
+    "id": 161,
     "type": "MUNICIPALITY"
   },
   {
@@ -1625,9 +495,9 @@
     "type": "PROVINCE"
   },
   {
-    "name": "Flevoland",
-    "id": 20,
-    "type": "PROVINCE"
+    "name": "Culemborg",
+    "id": 56,
+    "type": "MUNICIPALITY"
   },
   {
     "name": "Friesland",
@@ -1650,48 +520,8 @@
     "type": "PROVINCE"
   },
   {
-    "name": "Den Helder",
-    "id": 234,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Culemborg",
-    "id": 56,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Aa en Hunze",
-    "id": 1,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Bloemendaal",
-    "id": 232,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Son en Breugel",
-    "id": 210,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Albrandswaard",
-    "id": 383,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Dronten",
-    "id": 15,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Lingewaard",
-    "id": 71,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Weert",
-    "id": 157,
+    "name": "Baarle-Nassau",
+    "id": 162,
     "type": "MUNICIPALITY"
   },
   {
@@ -1700,18 +530,8 @@
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Oudewater",
-    "id": 332,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Zeeland",
-    "id": 381,
-    "type": "PROVINCE"
-  },
-  {
-    "name": "Zaanstad",
-    "id": 270,
+    "name": "Baarn",
+    "id": 319,
     "type": "MUNICIPALITY"
   },
   {
@@ -1720,33 +540,13 @@
     "type": "PROVINCE"
   },
   {
-    "name": "Alphen-Chaam",
-    "id": 160,
+    "name": "Barendrecht",
+    "id": 385,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Roosendaal",
-    "id": 204,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Beesel",
-    "id": 126,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Gilze en Rijen",
-    "id": 183,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Schouwen-Duiveland",
-    "id": 375,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Voerendaal",
-    "id": 156,
+    "name": "Waadhoeke",
+    "id": 444,
     "type": "MUNICIPALITY"
   },
   {
@@ -1755,48 +555,28 @@
     "type": "PROVINCE"
   },
   {
-    "name": "Utrecht",
-    "id": 345,
-    "type": "PROVINCE"
-  },
-  {
     "name": "Overijssel",
     "id": 301,
     "type": "PROVINCE"
   },
   {
-    "name": "Almere",
-    "id": 14,
+    "name": "Utrecht",
+    "id": 345,
+    "type": "PROVINCE"
+  },
+  {
+    "name": "Scherpenzeel",
+    "id": 89,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Halderberge",
-    "id": 187,
+    "name": "Barneveld",
+    "id": 49,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Weststellingwerf",
-    "id": 44,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Oldambt",
-    "id": 115,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Opsterland",
-    "id": 37,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Berg en Dal",
-    "id": 50,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Zwolle",
-    "id": 300,
+    "name": "Beekdaelen",
+    "id": 461,
     "type": "MUNICIPALITY"
   },
   {
@@ -1805,153 +585,23 @@
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Dalfsen",
-    "id": 278,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Maasgouw",
-    "id": 138,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Borne",
-    "id": 277,
-    "type": "MUNICIPALITY"
-  },
-  {
     "name": "Blaricum",
     "id": 231,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Enkhuizen",
-    "id": 238,
+    "name": "Beesel",
+    "id": 126,
     "type": "MUNICIPALITY"
   },
   {
-    "name": "Dordrecht",
-    "id": 392,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Leidschendam-Voorburg",
-    "id": 411,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Waterland",
-    "id": 266,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Hendrik-Ido-Ambacht",
-    "id": 399,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Heeze-Leende",
-    "id": 188,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Pekela",
-    "id": 116,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Olst-Wijhe",
-    "id": 290,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Reusel-De Mierden",
-    "id": 203,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Stadskanaal",
-    "id": 118,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Goeree-Overflakkee",
-    "id": 394,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Duiven",
-    "id": 60,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Roerdalen",
-    "id": 146,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Papendrecht",
-    "id": 422,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Huizen",
-    "id": 250,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Uitgeest",
-    "id": 263,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Steenbergen",
-    "id": 211,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Edam-Volendam",
-    "id": 237,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Hof van Twente",
-    "id": 286,
+    "name": "Bergeijk",
+    "id": 163,
     "type": "MUNICIPALITY"
   },
   {
     "name": "Maassluis",
     "id": 413,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Zaltbommel",
-    "id": 97,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Hilversum",
-    "id": 247,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Tiel",
-    "id": 90,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Opmeer",
-    "id": 257,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Zuidplas",
-    "id": 441,
-    "type": "MUNICIPALITY"
-  },
-  {
-    "name": "Lelystad",
-    "id": 16,
     "type": "MUNICIPALITY"
   },
   {
@@ -1970,6 +620,11 @@
     "type": "RAILWAY"
   },
   {
+    "name": "Berg en Dal",
+    "id": 50,
+    "type": "MUNICIPALITY"
+  },
+  {
     "name": "ProRail Oost",
     "id": 1124,
     "type": "RAILWAY"
@@ -1980,9 +635,19 @@
     "type": "RAILWAY"
   },
   {
+    "name": "Dronten",
+    "id": 15,
+    "type": "MUNICIPALITY"
+  },
+  {
     "name": "ProRail Noord",
     "id": 1126,
     "type": "RAILWAY"
+  },
+  {
+    "name": "Echt-Susteren",
+    "id": 129,
+    "type": "MUNICIPALITY"
   },
   {
     "name": "ProRail Zuid-Oost",
@@ -1990,13 +655,1393 @@
     "type": "RAILWAY"
   },
   {
+    "name": "Edam-Volendam",
+    "id": 237,
+    "type": "MUNICIPALITY"
+  },
+  {
     "name": "ProRail Zuid-Holland",
     "id": 1128,
     "type": "RAILWAY"
   },
   {
+    "name": "Bergen (L.)",
+    "id": 127,
+    "type": "MUNICIPALITY"
+  },
+  {
     "name": "ProRail Noord-West",
     "id": 1129,
     "type": "RAILWAY"
+  },
+  {
+    "name": "Bergen (NH.)",
+    "id": 229,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Amsterdam Centrum",
+    "id": 1135,
+    "type": "SUBMUNICIPALITY"
+  },
+  {
+    "name": "Amsterdam West",
+    "id": 1138,
+    "type": "SUBMUNICIPALITY"
+  },
+  {
+    "name": "Flevoland",
+    "id": 20,
+    "type": "PROVINCE"
+  },
+  {
+    "name": "Bergen op Zoom",
+    "id": 164,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Zeeland",
+    "id": 381,
+    "type": "PROVINCE"
+  },
+  {
+    "name": "Midden-Nederland District Zuid",
+    "id": 303,
+    "type": "ROAD_AUTHORITY"
+  },
+  {
+    "name": "Oost-Nederland District Oost",
+    "id": 307,
+    "type": "ROAD_AUTHORITY"
+  },
+  {
+    "name": "West-Nederland Noord District Zuid",
+    "id": 310,
+    "type": "ROAD_AUTHORITY"
+  },
+  {
+    "name": "Zee en Delta District Noord",
+    "id": 313,
+    "type": "ROAD_AUTHORITY"
+  },
+  {
+    "name": "Zuid-Nederland District Zuid-Oost",
+    "id": 317,
+    "type": "ROAD_AUTHORITY"
+  },
+  {
+    "name": "North Sea Port",
+    "id": 876,
+    "type": "MISCELLANEOUS"
+  },
+  {
+    "name": "Aa en Hunze",
+    "id": 1,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Almere",
+    "id": 14,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Simpelveld",
+    "id": 149,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Altena",
+    "id": 462,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Amersfoort",
+    "id": 318,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Beuningen",
+    "id": 52,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Bladel",
+    "id": 167,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Bodegraven-Reeuwijk",
+    "id": 387,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Boekel",
+    "id": 168,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Borger-Odoorn",
+    "id": 3,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Breda",
+    "id": 171,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Ede",
+    "id": 61,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Bronckhorst",
+    "id": 53,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Eersel",
+    "id": 177,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Brummen",
+    "id": 54,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Brunssum",
+    "id": 128,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Buren",
+    "id": 55,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Capelle aan den IJssel",
+    "id": 389,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Coevorden",
+    "id": 4,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Eijsden-Margraten",
+    "id": 130,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Dalfsen",
+    "id": 278,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Eindhoven",
+    "id": 178,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Dantumadiel",
+    "id": 23,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "De Bilt",
+    "id": 323,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "De Fryske Marren",
+    "id": 24,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Delft",
+    "id": 391,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Den Helder",
+    "id": 234,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "De Ronde Venen",
+    "id": 324,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Enkhuizen",
+    "id": 238,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Deurne",
+    "id": 174,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Deventer",
+    "id": 279,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "De Wolden",
+    "id": 5,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Diemen",
+    "id": 235,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Dinkelland",
+    "id": 280,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Doesburg",
+    "id": 57,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Doetinchem",
+    "id": 58,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Dongen",
+    "id": 175,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Dordrecht",
+    "id": 392,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Drechterland",
+    "id": 236,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Druten",
+    "id": 59,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Duiven",
+    "id": 60,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Eemnes",
+    "id": 325,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Eemsdelta",
+    "id": 506,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Emmen",
+    "id": 6,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Enschede",
+    "id": 281,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Etten-Leur",
+    "id": 179,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Epe",
+    "id": 63,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Ermelo",
+    "id": 64,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Gemert-Bakel",
+    "id": 182,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Gennep",
+    "id": 131,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Goeree-Overflakkee",
+    "id": 394,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Goes",
+    "id": 369,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Groningen",
+    "id": 107,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Gulpen-Wittem",
+    "id": 132,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Haaksbergen",
+    "id": 282,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Haarlem",
+    "id": 240,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Haarlemmermeer",
+    "id": 242,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Halderberge",
+    "id": 187,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Stede Broec",
+    "id": 261,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Hardenberg",
+    "id": 283,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Harderwijk",
+    "id": 66,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Hattem",
+    "id": 67,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Heemskerk",
+    "id": 243,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Heemstede",
+    "id": 244,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Heerde",
+    "id": 68,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Heerlen",
+    "id": 133,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Heerenveen",
+    "id": 29,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Heeze-Leende",
+    "id": 188,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Heiloo",
+    "id": 246,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Hellendoorn",
+    "id": 284,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "'s-Gravenhage",
+    "id": 428,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Het Hogeland",
+    "id": 479,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "'s-Hertogenbosch",
+    "id": 206,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Heumen",
+    "id": 69,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Heusden",
+    "id": 190,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Hillegom",
+    "id": 400,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Hilvarenbeek",
+    "id": 191,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Tiel",
+    "id": 90,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Hilversum",
+    "id": 247,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Hulst",
+    "id": 370,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Hoeksche Waard",
+    "id": 466,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Hof van Twente",
+    "id": 286,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Hollands Kroon",
+    "id": 248,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Hoogeveen",
+    "id": 7,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Horst aan de Maas",
+    "id": 134,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Houten",
+    "id": 326,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Kaag en Braassem",
+    "id": 401,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Kampen",
+    "id": 287,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Krimpenerwaard",
+    "id": 406,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Laarbeek",
+    "id": 192,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Land van Cuijk",
+    "id": 579,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Landsmeer",
+    "id": 252,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Lansingerland",
+    "id": 407,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Leeuwarden",
+    "id": 32,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Leiden",
+    "id": 409,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Leiderdorp",
+    "id": 410,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Leidschendam-Voorburg",
+    "id": 411,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Valkenswaard",
+    "id": 214,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Lelystad",
+    "id": 16,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Leusden",
+    "id": 328,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Leudal",
+    "id": 137,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Opmeer",
+    "id": 257,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Lingewaard",
+    "id": 71,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Lisse",
+    "id": 412,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Lochem",
+    "id": 72,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Loon op Zand",
+    "id": 194,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Lopik",
+    "id": 329,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Losser",
+    "id": 288,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Maasdriel",
+    "id": 73,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Maasgouw",
+    "id": 138,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Maashorst",
+    "id": 578,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Maastricht",
+    "id": 139,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Medemblik",
+    "id": 255,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Meerssen",
+    "id": 140,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Papendrecht",
+    "id": 422,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Meierijstad",
+    "id": 195,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Meppel",
+    "id": 8,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Middelburg",
+    "id": 372,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Midden-Delfland",
+    "id": 414,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Midden-Drenthe",
+    "id": 9,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Moerdijk",
+    "id": 197,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Midden-Groningen",
+    "id": 446,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Montfoort",
+    "id": 330,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Montferland",
+    "id": 74,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Mook en Middelaar",
+    "id": 141,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Neder-Betuwe",
+    "id": 75,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Nissewaard",
+    "id": 417,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Nederweert",
+    "id": 142,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Nuenen, Gerwen en Nederwetten",
+    "id": 198,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Nieuwegein",
+    "id": 331,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Nieuwkoop",
+    "id": 416,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Nijkerk",
+    "id": 77,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Nijmegen",
+    "id": 78,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Noardeast-Fryslân",
+    "id": 467,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Noord-Beveland",
+    "id": 373,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Noordenveld",
+    "id": 10,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Nunspeet",
+    "id": 79,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Noordoostpolder",
+    "id": 17,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Noordwijk",
+    "id": 418,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Oirschot",
+    "id": 199,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Oisterwijk",
+    "id": 200,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Oldambt",
+    "id": 115,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Oldebroek",
+    "id": 80,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Olst-Wijhe",
+    "id": 290,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Ommen",
+    "id": 291,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Oost Gelre",
+    "id": 81,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Oosterhout",
+    "id": 201,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Ooststellingwerf",
+    "id": 36,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Oostzaan",
+    "id": 256,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Opsterland",
+    "id": 37,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Oss",
+    "id": 202,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Renkum",
+    "id": 85,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Oude IJsselstreek",
+    "id": 82,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Ouder-Amstel",
+    "id": 258,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Oudewater",
+    "id": 332,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Overbetuwe",
+    "id": 83,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Peel en Maas",
+    "id": 145,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Renswoude",
+    "id": 333,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Reusel-De Mierden",
+    "id": 203,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Pekela",
+    "id": 116,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Pijnacker-Nootdorp",
+    "id": 423,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Purmerend",
+    "id": 259,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Woudenberg",
+    "id": 343,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Putten",
+    "id": 84,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Ridderkerk",
+    "id": 424,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Raalte",
+    "id": 292,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Reimerswaal",
+    "id": 374,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Rheden",
+    "id": 86,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Rhenen",
+    "id": 334,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Rijssen-Holten",
+    "id": 293,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Rijswijk",
+    "id": 425,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Roerdalen",
+    "id": 146,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Roermond",
+    "id": 147,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Roosendaal",
+    "id": 204,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Rozendaal",
+    "id": 88,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Rotterdam",
+    "id": 426,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Rucphen",
+    "id": 205,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Schagen",
+    "id": 260,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Schiedam",
+    "id": 427,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Schouwen-Duiveland",
+    "id": 375,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Sint-Michielsgestel",
+    "id": 208,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Sittard-Geleen",
+    "id": 150,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Veere",
+    "id": 379,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Sliedrecht",
+    "id": 429,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Sluis",
+    "id": 376,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Smallingerland",
+    "id": 39,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Steenbergen",
+    "id": 211,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Soest",
+    "id": 335,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Someren",
+    "id": 209,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Son en Breugel",
+    "id": 210,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Stadskanaal",
+    "id": 118,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Terschelling",
+    "id": 41,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Staphorst",
+    "id": 294,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Tholen",
+    "id": 378,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Steenwijkerland",
+    "id": 295,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Stein",
+    "id": 151,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Súdwest-Fryslân",
+    "id": 40,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Terneuzen",
+    "id": 377,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Texel",
+    "id": 262,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Teylingen",
+    "id": 431,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Tilburg",
+    "id": 212,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Tubbergen",
+    "id": 296,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Twenterand",
+    "id": 297,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Tynaarlo",
+    "id": 11,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Tytsjerksteradiel",
+    "id": 42,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Uitgeest",
+    "id": 263,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Uithoorn",
+    "id": 264,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Urk",
+    "id": 18,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Utrecht",
+    "id": 337,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Veendam",
+    "id": 120,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Utrechtse Heuvelrug",
+    "id": 338,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Valkenburg aan de Geul",
+    "id": 153,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Veldhoven",
+    "id": 215,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Velsen",
+    "id": 265,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Venlo",
+    "id": 154,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Venray",
+    "id": 155,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Vijfheerenlanden",
+    "id": 464,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Vlissingen",
+    "id": 380,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Vlaardingen",
+    "id": 432,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Vlieland",
+    "id": 43,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Voorne aan Zee",
+    "id": 904,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Voorschoten",
+    "id": 433,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Waalre",
+    "id": 217,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Voorst",
+    "id": 91,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Vught",
+    "id": 216,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Weesp",
+    "id": 267,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Waalwijk",
+    "id": 218,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Waddinxveen",
+    "id": 434,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Wageningen",
+    "id": 92,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Wassenaar",
+    "id": 435,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Waterland",
+    "id": 266,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Weert",
+    "id": 157,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "West Betuwe",
+    "id": 463,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "West Maas en Waal",
+    "id": 93,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Westervoort",
+    "id": 94,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Westerkwartier",
+    "id": 480,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Westland",
+    "id": 436,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Westerveld",
+    "id": 12,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Woensdrecht",
+    "id": 220,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Westerwolde",
+    "id": 445,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Weststellingwerf",
+    "id": 44,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Wierden",
+    "id": 298,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Wijchen",
+    "id": 95,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Wijdemeren",
+    "id": 268,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Wijk bij Duurstede",
+    "id": 341,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Winterswijk",
+    "id": 96,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Woerden",
+    "id": 342,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Wormerland",
+    "id": 269,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Zaanstad",
+    "id": 270,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Zaltbommel",
+    "id": 97,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Zandvoort",
+    "id": 271,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Zeewolde",
+    "id": 19,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Zeist",
+    "id": 344,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Zevenaar",
+    "id": 98,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Zoetermeer",
+    "id": 439,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Zoeterwoude",
+    "id": 440,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Zuidplas",
+    "id": 441,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Zutphen",
+    "id": 99,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Zundert",
+    "id": 222,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Zwartewaterland",
+    "id": 299,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Zwijndrecht",
+    "id": 442,
+    "type": "MUNICIPALITY"
+  },
+  {
+    "name": "Zwolle",
+    "id": 300,
+    "type": "MUNICIPALITY"
   }
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The NDW have performed critical changes in their API. a lot of contact attributes are now nullable, also the prefix attribute of a person can now be null. The same goes for remarks.

The above information has been verified by the NDW

## Motivation and context

The package crashes now when trying to import Melvin data, since these fields are in almost every situation, its critical that this is resolved quickly.

If it fixes an open issue, please link to the issue here (if you write `fixes #num`
or `closes #num`, the issue will be automatically closed when the pull is accepted.)

## How has this been tested?

I have ran a test importing the data. Alot of situations had null values for the above fields
Running the integration tests will show that it now works again

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the [schema](tests/_files/situations-schema.json), I have updated it accordingly.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
